### PR TITLE
refactor: use async/await version of multihashing-async

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "multihashing-async": "^0.5.1",
+    "multihashing-async": "multiformats/js-multihashing-async#feat/async-iterators",
     "secp256k1": "^3.5.0"
   },
   "devDependencies": {

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -17,23 +17,13 @@ module.exports = (randomBytes) => {
   }
 
   async function hashAndSign (key, msg) {
-    const digest = await new Promise((resolve, reject) => {
-      multihashing.digest(msg, HASH_ALGORITHM, (err, digest) => {
-        if (err) return reject(err)
-        resolve(digest)
-      })
-    })
+    const digest = await multihashing.digest(msg, HASH_ALGORITHM)
     const sig = secp256k1.sign(digest, key)
     return secp256k1.signatureExport(sig.signature)
   }
 
   async function hashAndVerify (key, sig, msg) {
-    const digest = await new Promise((resolve, reject) => {
-      multihashing.digest(msg, HASH_ALGORITHM, (err, digest) => {
-        if (err) return reject(err)
-        resolve(digest)
-      })
-    })
+    const digest = await multihashing.digest(msg, HASH_ALGORITHM)
     sig = secp256k1.signatureImport(sig)
     return secp256k1.verify(digest, sig, key)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -30,13 +30,9 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
       return this.bytes.equals(key.bytes)
     }
 
-    async hash () {
-      return new Promise((resolve, reject) => {
-        multihashing(this.bytes, 'sha2-256', (err, res) => {
-          if (err) return reject(err)
-          resolve(res)
-        })
-      })
+    // Note: returns a Promise
+    hash () {
+      return multihashing(this.bytes, 'sha2-256')
     }
   }
 
@@ -71,13 +67,9 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
       return this.bytes.equals(key.bytes)
     }
 
-    async hash () {
-      return new Promise((resolve, reject) => {
-        multihashing(this.bytes, 'sha2-256', (err, res) => {
-          if (err) return reject(err)
-          resolve(res)
-        })
-      })
+    // Note: returns a Promise
+    hash () {
+      return multihashing(this.bytes, 'sha2-256')
     }
   }
 


### PR DESCRIPTION
Parent pull request: https://github.com/libp2p/js-libp2p-crypto-secp256k1/pull/9